### PR TITLE
feat: deployment via nginx rev-proxy & certbot

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
     restart: unless-stopped
 
   perplexica-backend:
+    container_name: perplexica-backend
     build:
       context: .
       dockerfile: backend.dockerfile
@@ -33,12 +34,13 @@ services:
     restart: unless-stopped
 
   perplexica-frontend:
+    container_name: perplexica-frontend
     build:
       context: .
       dockerfile: app.dockerfile
       args:
-        - NEXT_PUBLIC_API_URL=http://127.0.0.1:3001/api
-        - NEXT_PUBLIC_WS_URL=ws://127.0.0.1:3001
+        - NEXT_PUBLIC_API_URL=https://backend.chat.starknet.builders/api
+        - NEXT_PUBLIC_WS_URL=wss://backend.chat.starknet.builders
     depends_on:
       - perplexica-backend
     ports:
@@ -70,9 +72,27 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
     restart: 'no'
 
+  nginx:
+    image: valian/docker-nginx-auto-ssl
+    restart: on-failure
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ssl_data:/etc/resty-auto-ssl
+    environment:
+      ALLOWED_DOMAINS: '(backend.)?chat.starknet.builder'
+      SITES: 'backend.chat.starknet.builders=perplexica-backend:3001;chat.starknet.builders=perplexica-frontend:3000'
+    networks:
+      - perplexica-network
+    depends_on:
+      - perplexica-backend
+      - perplexica-frontend
+
 networks:
   perplexica-network:
 
 volumes:
   backend-dbstore:
   mongodb-data:
+  ssl_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
       args:
         - NEXT_PUBLIC_API_URL=https://backend.chat.starknet.builders/api
         - NEXT_PUBLIC_WS_URL=wss://backend.chat.starknet.builders
+        - NEXT_PUBLIC_HOSTED_MODE=true
     depends_on:
       - perplexica-backend
     ports:


### PR DESCRIPTION
This pull request updates the production `docker-compose.yaml` to setup a nginx reverse proxy and automatically generate SSL certificates via certbot.